### PR TITLE
packed: sort faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ module.exports = function sort (arr, ids, precise) {
 
   if (!ids) ids = new Uint32Array(l)
 
-  // do native sort
-  packed = packed.sort()
+  packed.sort((a, b) => (a - b))
 
   for (var i = 0; i < l; i++) {
     ids[i] = packedInt[i << 1] & idMask


### PR DESCRIPTION
yepp, its faster .. benchmark https://jsbench.github.io/#c90f8f13202ce5498f811ff79fb281ed

also `.sort()` mutates in-place
